### PR TITLE
Fetch all labels

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2521,11 +2521,13 @@ function processIssue(octokit, repo, owner, issue_number, htmlUrl, description, 
             return;
         }
         // Labels registered in the repository
-        const labelsForRepoResp = yield octokit.issues.listLabelsForRepo({
-            owner,
-            repo,
+        const labelsForRepoResp = yield octokit.paginate(octokit.issues.listLabelsForRepo, {
+            owner: 'mlflow',
+            repo: 'mlflow',
         });
-        const labelsForRepo = labelsForRepoResp.data.map(labels_1.getName);
+        logger.debug(labelsForRepoResp);
+        throw Error();
+        const labelsForRepo = labelsForRepoResp.map(labels_1.getName);
         const labelsRegistered = labels.filter(({ name }) => labelsForRepo.includes(name));
         if (labelsRegistered.length === 0) {
             logger.debug('No registered labels found');

--- a/dist/index.js
+++ b/dist/index.js
@@ -2526,6 +2526,7 @@ function processIssue(octokit, repo, owner, issue_number, htmlUrl, description, 
             repo: 'mlflow',
         });
         logger.debug(labelsForRepoResp);
+        logger.debug(labelsForRepoResp.length);
         throw Error();
         const labelsForRepo = labelsForRepoResp.map(labels_1.getName);
         const labelsRegistered = labels.filter(({ name }) => labelsForRepo.includes(name));

--- a/dist/index.js
+++ b/dist/index.js
@@ -2521,14 +2521,11 @@ function processIssue(octokit, repo, owner, issue_number, htmlUrl, description, 
             return;
         }
         // Labels registered in the repository
-        const labelsForRepoResp = yield octokit.paginate(octokit.issues.listLabelsForRepo, {
-            owner: 'mlflow',
-            repo: 'mlflow',
+        const labelsForRepoData = yield octokit.paginate(octokit.issues.listLabelsForRepo, {
+            owner,
+            repo,
         });
-        logger.debug(labelsForRepoResp);
-        logger.debug(labelsForRepoResp.length);
-        throw Error();
-        const labelsForRepo = labelsForRepoResp.map(labels_1.getName);
+        const labelsForRepo = labelsForRepoData.map(labels_1.getName);
         const labelsRegistered = labels.filter(({ name }) => labelsForRepo.includes(name));
         if (labelsRegistered.length === 0) {
             logger.debug('No registered labels found');

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ async function processIssue(
     },
   );
   logger.debug(labelsForRepoResp);
+  logger.debug(labelsForRepoResp.length);
 
   throw Error();
   const labelsForRepo = labelsForRepoResp.map(getName);

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,18 +33,15 @@ async function processIssue(
   }
 
   // Labels registered in the repository
-  const labelsForRepoResp = await octokit.paginate(
+  const labelsForRepoData = await octokit.paginate(
     octokit.issues.listLabelsForRepo,
     {
-      owner: 'mlflow',
-      repo: 'mlflow',
+      owner,
+      repo,
     },
   );
-  logger.debug(labelsForRepoResp);
-  logger.debug(labelsForRepoResp.length);
 
-  throw Error();
-  const labelsForRepo = labelsForRepoResp.map(getName);
+  const labelsForRepo = labelsForRepoData.map(getName);
   const labelsRegistered = labels.filter(({ name }) =>
     labelsForRepo.includes(name),
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,11 +33,17 @@ async function processIssue(
   }
 
   // Labels registered in the repository
-  const labelsForRepoResp = await octokit.issues.listLabelsForRepo({
-    owner,
-    repo,
-  });
-  const labelsForRepo = labelsForRepoResp.data.map(getName);
+  const labelsForRepoResp = await octokit.paginate(
+    octokit.issues.listLabelsForRepo,
+    {
+      owner: 'mlflow',
+      repo: 'mlflow',
+    },
+  );
+  logger.debug(labelsForRepoResp);
+
+  throw Error();
+  const labelsForRepo = labelsForRepoResp.map(getName);
   const labelsRegistered = labels.filter(({ name }) =>
     labelsForRepo.includes(name),
   );


### PR DESCRIPTION
## Motivation

`octokit.issues.listLabelsForRepo` returns only labels in the first page.
To fetch all labels, it's necessary to use `octokit.paginate`.

## PR Type

What kind of change does this PR introduce?

- [x] `bug-fix`
- [ ] `new-feature`
- [ ] `enhancement`
